### PR TITLE
Adds Document#each_transaction

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--require spec_helper

--- a/lib/rex12.rb
+++ b/lib/rex12.rb
@@ -3,6 +3,7 @@ require "rex12/parse_error"
 require "rex12/element"
 require "rex12/segment"
 require "rex12/document"
+require 'rex12/transaction'
 
 module REX12
   # Your code goes here...

--- a/lib/rex12/transaction.rb
+++ b/lib/rex12/transaction.rb
@@ -1,0 +1,20 @@
+# Represents a collection of all EDI elements between the ST/SE segments of a single EDI document transaction.
+# An EDI document may have multiple transactions in it.
+module REX12; class Transaction
+
+  # @return REX12::Segment - The ISA segment from the EDI document this transaction belongs to
+  attr_reader :isa_segment
+
+  # @return REX12::Segment - The GS segment from the EDI document this transaction belongs to
+  attr_reader :gs_segment
+
+  # @return Array<REX12::Segment> - All the segments that comprise this EDI Transaction
+  attr_reader :segments
+
+  def initialize(isa_segment, gs_segment, segments)
+    @isa_segment = isa_segment
+    @gs_segment = gs_segment
+    @segments = segments
+  end
+  
+end; end

--- a/spec/rex12/document_spec.rb
+++ b/spec/rex12/document_spec.rb
@@ -1,7 +1,11 @@
 describe REX12::Document do
-  let :base_text do
+  subject { described_class }
+
+  let(:isa) { "ISA*00*          *00*          *ZZ*RECEIVERID     *12*SENDERID       *100325*1113*U*00403*000011436*0*T*>~\n" }
+  let(:iea) { "IEA*1*000011436~\n" }
+
+  let(:base_edi) do
     str = <<edi_text
-ISA*00*          *00*          *ZZ*RECEIVERID     *12*SENDERID       *100325*1113*U*00403*000011436*0*T*>~
 GS*FA*RECEIVERID*SENDERID*20100325*1113*24712*X*004030~
 ST*997*1136~
 AK1*PO*142~
@@ -10,14 +14,16 @@ AK5*A~
 AK9*A*1*1*1~
 SE*6*1136~
 GE*1*24712~
-IEA*1*000011436~
 edi_text
-    str
+        str
   end
+
+  let(:base_text) { isa + base_edi + iea }
+
   describe '#parse' do
     it "should handle base text" do
       base_text.gsub!("\n",'')
-      segs = described_class.parse(base_text)
+      segs = subject.parse(base_text)
       expect(segs.length).to eq 10
       # make sure it's parsing segments properly
       st_seg = segs[2]
@@ -26,54 +32,62 @@ edi_text
       expect(st_seg.segment_type).to eq 'ST'
       expect(segs[4].elements.last.sub_elements).to eq ['01','42']
     end
+
     it "should handle LF after segment terminator" do
-      segs = described_class.parse(base_text)
+      segs = subject.parse(base_text)
       expect(segs.length).to eq 10
       # make sure it's parsing segments properly
       expect(segs[2].value).to eq 'ST*997*1136'
     end
+
     it "should handle CR after segment terminator" do
       base_text.gsub!("\n","\r")
-      segs = described_class.parse(base_text)
+      segs = subject.parse(base_text)
       expect(segs.length).to eq 10
       # make sure it's parsing segments properly
       expect(segs[2].value).to eq 'ST*997*1136'
     end
+
     it "should handle CRLF after segment terminator" do
       base_text.gsub!("\n","\r\n")
-      segs = described_class.parse(base_text)
+      segs = subject.parse(base_text)
       expect(segs.length).to eq 10
       # make sure it's parsing segments properly
       expect(segs[2].value).to eq 'ST*997*1136'
     end
+
     it "should handle block form" do
       segs = []
-      expect(described_class.parse(base_text) {|s| segs << s}).to be_nil
+      expect(subject.parse(base_text) {|s| segs << s}).to be_nil
       expect(segs.length).to eq 10
       # make sure it's parsing segments properly
       expect(segs[2].value).to eq 'ST*997*1136'
     end
+
     it "should raise parse error if first segment isn't ISA" do
       base_text.gsub!("\n",'')
       base_text.gsub!("ISA*","OTR*")
-      expect {described_class.parse(base_text)}.to raise_error REX12::ParseError
+      expect {subject.parse(base_text)}.to raise_error REX12::ParseError
     end
+
     it "should raise parse error if second segment isn't GS" do
       base_text.gsub!("\n",'')
       base_text.gsub!("GS*","OTR*")
-      expect {described_class.parse(base_text)}.to raise_error REX12::ParseError
+      expect {subject.parse(base_text)}.to raise_error REX12::ParseError
     end
   end
+
   describe "#read" do
     it "should load file and collect responses from foreach" do
-      segs = described_class.read('spec/support/997.txt')
+      segs = subject.read('spec/support/997.txt')
       expect(segs.length).to eq 10
       # make sure it's parsing segments properly
       expect(segs[2].value).to eq 'ST*997*1136'
     end
+
     it "should support block form" do
       segs = []
-      expect(described_class.read('spec/support/997.txt') {|s| segs << s}).to be_nil
+      expect(subject.read('spec/support/997.txt') {|s| segs << s}).to be_nil
       expect(segs.length).to eq 10
       # make sure it's parsing segments properly
       expect(segs[2].value).to eq 'ST*997*1136'
@@ -82,10 +96,38 @@ edi_text
     context "with IO object" do
       it "reads edi data from an IO object" do
         File.open("spec/support/997.txt", "r") do |f|
-          segs = described_class.read('spec/support/997.txt')
+          segs = subject.read('spec/support/997.txt')
           expect(segs.length).to eq 10
         end
       end
+    end
+  end
+
+  describe "each_transaction" do
+    let (:multiple_transactions) { isa + base_edi + base_edi + iea }
+
+    def evaluate_transactions transactions
+      expect(transactions.length).to eq 2
+      transaction = transactions.first
+      # Make sure the ISA and GS segements are attached to the transaction
+      expect(transaction.isa_segment).not_to be_nil
+      expect(transaction.isa_segment.value).to eq "ISA*00*          *00*          *ZZ*RECEIVERID     *12*SENDERID       *100325*1113*U*00403*000011436*0*T*>"
+      expect(transaction.gs_segment).not_to be_nil
+      expect(transaction.gs_segment.value).to eq "GS*FA*RECEIVERID*SENDERID*20100325*1113*24712*X*004030"
+      expect(transaction.segments.length).to eq 6
+      # Make sure the segments are in order and the ST/SE ones are captured
+      expect(transaction.segments.first.value).to eq "ST*997*1136"
+      expect(transaction.segments.last.value).to eq "SE*6*1136"
+    end
+
+    it "parses all transactions from EDI text using block" do
+      yielded = []
+      subject.each_transaction(multiple_transactions) {|transaction| yielded << transaction }
+      evaluate_transactions(yielded)
+    end
+
+    it "parses all transactions from EDI text" do
+      evaluate_transactions(subject.each_transaction(multiple_transactions))
     end
   end
 end

--- a/spec/rex12/document_spec.rb
+++ b/spec/rex12/document_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe REX12::Document do
   let :base_text do
     str = <<edi_text

--- a/spec/rex12/document_spec.rb
+++ b/spec/rex12/document_spec.rb
@@ -78,5 +78,14 @@ edi_text
       # make sure it's parsing segments properly
       expect(segs[2].value).to eq 'ST*997*1136'
     end
+
+    context "with IO object" do
+      it "reads edi data from an IO object" do
+        File.open("spec/support/997.txt", "r") do |f|
+          segs = described_class.read('spec/support/997.txt')
+          expect(segs.length).to eq 10
+        end
+      end
+    end
   end
 end

--- a/spec/rex12/element_spec.rb
+++ b/spec/rex12/element_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe REX12::Element do
   describe '#value' do
     it "should return raw text" do

--- a/spec/rex12/parse_error_spec.rb
+++ b/spec/rex12/parse_error_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe REX12::ParseError do
   it "should extend StandardError" do
     expect(described_class.new("my message").is_a?(StandardError)).to be_truthy

--- a/spec/rex12/segment_spec.rb
+++ b/spec/rex12/segment_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe REX12::Segment do
   let :base_text do
     'DTM*ACK*20000415*0830*ED>XYZ'

--- a/spec/rex12_spec.rb
+++ b/spec/rex12_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe REX12 do
   it "has a version number" do
     expect(REX12::VERSION).not_to be nil


### PR DESCRIPTION
There's a few minor project adjustments I made, like adding the spec_helper require to .rspec and removing from the _spec.rb files and allowing IO objects to be passed to Document#parse.

Then added that each_transaction method we talked about.